### PR TITLE
Fix insecure payment amount calculation 

### DIFF
--- a/app/actions/stripe.ts
+++ b/app/actions/stripe.ts
@@ -3,6 +3,49 @@
 import { stripe } from "@/lib/stripe"
 import { createClient } from "@/lib/supabase/server"
 
+/**
+ * Convert payment amount to Stripe's smallest currency unit
+ * @param amount - The payment amount
+ * @param currency - The currency code (USD or UGX)
+ * @returns The amount in smallest currency unit for Stripe
+ */
+function convertToStripeAmount(amount: number, currency: string): number {
+  // Validate amount
+  if (amount <= 0) {
+    throw new Error("Payment amount must be greater than zero")
+  }
+
+  if (!Number.isFinite(amount)) {
+    throw new Error("Payment amount must be a valid number")
+  }
+
+  const currencyUpper = currency.toUpperCase()
+
+  switch (currencyUpper) {
+    case "USD":
+      // USD uses cents (multiply by 100)
+      return Math.round(amount * 100)
+
+    case "UGX":
+      // UGX requires special handling:
+      // - Multiply by 100 for Stripe's two-decimal representation
+      // - Ensure the result is divisible by 100 (whole UGX only)
+      const ugxAmount = Math.round(amount * 100)
+
+      // Stripe will round to nearest 100, so we should too
+      const roundedAmount = Math.round(ugxAmount / 100) * 100
+
+      if (roundedAmount !== ugxAmount) {
+        console.warn(`UGX amount ${amount} was rounded from ${ugxAmount} to ${roundedAmount}`)
+      }
+
+      return roundedAmount
+
+    default:
+      throw new Error(`Unsupported currency: ${currency}`)
+  }
+}
+
 export async function createRentPaymentSession(paymentId: string) {
   const supabase = await createClient()
 
@@ -37,7 +80,7 @@ export async function createRentPaymentSession(paymentId: string) {
             name: `Rent Payment - ${payment.tenants.properties.title}`,
             description: `${payment.tenants.properties.address} - Due ${new Date(payment.due_date).toLocaleDateString()}`,
           },
-          unit_amount: Math.round(payment.amount * 100), // Convert to cents
+          unit_amount: convertToStripeAmount(payment.amount, payment.currency),
         },
         quantity: 1,
       },


### PR DESCRIPTION
- Add convertToStripeAmount() helper function for currency-aware conversion
- Handle USD correctly (multiply by 100 for cents)
- Handle UGX correctly (multiply by 100, round to nearest 100)
- Add amount validation (positive, finite numbers)
- Add logging for UGX rounding adjustments
- Prevent incorrect payment charges for different currencies

Fixes issue where payment amounts were calculated incorrectly for UGX.
Closes #4 