### PR TITLE
Fix: Correct Supabase client configuration for dashboard data retrieval

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -1,22 +1,9 @@
-import { createServerClient } from "@supabase/ssr"
-import { cookies } from "next/headers"
+import { getServiceClient } from "@/lib/supabase/server"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Building2, Users, Wrench, DollarSign, Building, UserCircle } from "lucide-react"
 
 export default async function DashboardPage() {
-  const cookieStore = await cookies()
-  const supabase = createServerClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!, {
-    cookies: {
-      getAll() {
-        return cookieStore.getAll()
-      },
-      setAll(cookiesToSet: any) {
-        try {
-          cookiesToSet.forEach((cookie: any) => cookieStore.set(cookie.name, cookie.value, cookie.options))
-        } catch {}
-      },
-    },
-  })
+  const supabase = getServiceClient()
 
   const [
     { count: propertiesCount },

--- a/app/api/dashboard/stats/route.ts
+++ b/app/api/dashboard/stats/route.ts
@@ -1,29 +1,12 @@
-import { createServerClient } from "@supabase/ssr"
-import { cookies } from "next/headers"
+import { getServiceClient } from "@/lib/supabase/server"
 import { logger } from "@/lib/logger"
 import { successResponse, handleApiError } from "@/lib/api-response"
 
 const log = logger.child("api:dashboard:stats")
 
-function getServiceClient(cookieStore: any) {
-  return createServerClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!, {
-    cookies: {
-      getAll() {
-        return cookieStore.getAll()
-      },
-      setAll(cookiesToSet: any) {
-        try {
-          cookiesToSet.forEach((cookie: any) => cookieStore.set(cookie.name, cookie.value, cookie.options))
-        } catch {}
-      },
-    },
-  })
-}
-
 export async function GET() {
   try {
-    const cookieStore = await cookies()
-    const supabase = getServiceClient(cookieStore)
+    const supabase = getServiceClient()
 
     const [{ count: propertiesCount }, { data: unitsStats }, { data: tenantsStats }] = await Promise.all([
       // Get property count efficiently


### PR DESCRIPTION
- Replace incorrect createServerClient usage with getServiceClient() in dashboard page
- Fix API dashboard stats route to use centralized getServiceClient function
- Resolves issue #85: Properties, tenants, and units not being retrieved on dashboard

The issue was caused by using createServerClient from @supabase/ssr with service role key, which is incorrect. Service role operations should use createClient from @supabase/supabase-js directly, which is what getServiceClient() provides.

Fixes #85 