### PR TITLE
Fix: Resolve property creation RLS error by using correct Supabase cl…

### DIFF
--- a/app/(dashboard)/properties/[id]/edit/page.tsx
+++ b/app/(dashboard)/properties/[id]/edit/page.tsx
@@ -2,29 +2,13 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import Link from "next/link"
 import { ChevronLeft } from "lucide-react"
-import { cookies } from "next/headers"
-import { createServerClient } from "@supabase/ssr"
+import { getServiceClient } from "@/lib/supabase/server"
 import { EditPropertyForm } from "@/components/edit-property-form"
 
 export default async function EditPropertyPage({ params }: { params: Promise<{ id: string }> }) {
   const { id: propertyId } = await params
 
-  const cookieStore = await cookies()
-
-  const supabase = createServerClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!, {
-    cookies: {
-      getAll() {
-        return cookieStore.getAll()
-      },
-      setAll(cookiesToSet) {
-        try {
-          cookiesToSet.forEach(({ name, value, options }) => cookieStore.set(name, value, options))
-        } catch (error) {
-          console.error(" Error setting cookies:", error)
-        }
-      },
-    },
-  })
+  const supabase = getServiceClient()
 
   const { data: propertyData, error: propertyError } = await supabase
     .from("properties")

--- a/app/(dashboard)/properties/actions.ts
+++ b/app/(dashboard)/properties/actions.ts
@@ -1,6 +1,6 @@
 "use server"
 
-import { createServerClient } from "@supabase/ssr"
+import { getServiceClient } from "@/lib/supabase/server"
 import { revalidatePath } from "next/cache"
 import { redirect } from "next/navigation"
 import { logger } from "@/lib/logger"
@@ -8,25 +8,7 @@ import { logger } from "@/lib/logger"
 const log = logger.child("properties:actions")
 
 export async function createProperty(formData: FormData) {
-  const { cookies } = await import("next/headers")
-  const cookieStore = await cookies()
-
-  const supabase = createServerClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!, {
-    cookies: {
-      getAll() {
-        return cookieStore.getAll()
-      },
-      setAll(cookiesToSet) {
-        try {
-          cookiesToSet.forEach(({ name, value, options }) => {
-            cookieStore.set(name, value, options)
-          })
-        } catch {
-          // Handle errors when setting cookies
-        }
-      },
-    },
-  })
+  const supabase = getServiceClient()
 
   const location = formData.get("location") as string
 
@@ -58,25 +40,7 @@ export async function createProperty(formData: FormData) {
 }
 
 export async function updateProperty(formData: FormData) {
-  const { cookies } = await import("next/headers")
-  const cookieStore = await cookies()
-
-  const supabase = createServerClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!, {
-    cookies: {
-      getAll() {
-        return cookieStore.getAll()
-      },
-      setAll(cookiesToSet) {
-        try {
-          cookiesToSet.forEach(({ name, value, options }) => {
-            cookieStore.set(name, value, options)
-          })
-        } catch {
-          // Handle errors when setting cookies
-        }
-      },
-    },
-  })
+  const supabase = getServiceClient()
 
   const id = formData.get("id") as string
   const location = formData.get("location") as string
@@ -109,25 +73,7 @@ export async function updateProperty(formData: FormData) {
 }
 
 export async function deleteProperty(propertyId: string) {
-  const { cookies } = await import("next/headers")
-  const cookieStore = await cookies()
-
-  const supabase = createServerClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!, {
-    cookies: {
-      getAll() {
-        return cookieStore.getAll()
-      },
-      setAll(cookiesToSet) {
-        try {
-          cookiesToSet.forEach(({ name, value, options }) => {
-            cookieStore.set(name, value, options)
-          })
-        } catch {
-          // Handle errors when setting cookies
-        }
-      },
-    },
-  })
+  const supabase = getServiceClient()
 
   const { error } = await supabase.from("properties").delete().eq("id", propertyId)
 


### PR DESCRIPTION
…ient

- Replace incorrect createServerClient usage with getServiceClient() in property actions
- Fix createProperty, updateProperty, and deleteProperty functions
- Fix property edit page to use correct Supabase service client
- Resolves issue #80: Property creation fails with RLS policy violation

The issue was caused by using createServerClient from @supabase/ssr with service role key, which doesn't properly bypass RLS. Service role operations should use createClient from @supabase/supabase-js directly via getServiceClient(), which correctly bypasses RLS policies.

Fixes #80 