### PR TITLE
Fix: Resolve duplicate React keys for months issue

### DIFF
--- a/app/(dashboard)/accounting/expenses/actions.ts
+++ b/app/(dashboard)/accounting/expenses/actions.ts
@@ -173,12 +173,14 @@ export async function getExpenseReport(startDate: string, endDate: string, prope
   const expensesByCategory: Record<string, { total: number; budget: number; variance: number }> = {}
 
   for (const expense of expenses || []) {
-    const categoryName = expense.category?.category_name || "Uncategorized"
+    // Handle both array and object responses from Supabase
+    const category = Array.isArray(expense.category) ? expense.category[0] : expense.category
+    const categoryName = category?.category_name || "Uncategorized"
 
     if (!expensesByCategory[categoryName]) {
       expensesByCategory[categoryName] = {
         total: 0,
-        budget: expense.category?.budget_limit || 0,
+        budget: category?.budget_limit || 0,
         variance: 0,
       }
     }
@@ -264,7 +266,10 @@ export async function getMonthlyExpenseTrend(propertyId?: string) {
     monthlyTotals[monthKey] = (monthlyTotals[monthKey] || 0) + expense.amount
   }
 
-  return Object.entries(monthlyTotals).map(([month, total]) => ({ month, total }))
+  // Return unique months sorted by date
+  return Object.entries(monthlyTotals)
+    .map(([month, total]) => ({ month, total }))
+    .sort((a, b) => a.month.localeCompare(b.month))
 }
 
 export async function approveExpense(expenseId: string) {

--- a/app/(dashboard)/maintenance/new/page.tsx
+++ b/app/(dashboard)/maintenance/new/page.tsx
@@ -194,7 +194,7 @@ export default function NewMaintenanceRequestPage() {
                     const monthValue = date.toISOString().slice(0, 7)
                     const monthLabel = date.toLocaleString("default", { month: "long", year: "numeric" })
                     return (
-                      <SelectItem key={monthValue} value={monthValue}>
+                      <SelectItem key={`month-${i}-${monthValue}`} value={monthValue}>
                         {monthLabel}
                       </SelectItem>
                     )

--- a/app/(dashboard)/reports/page.tsx
+++ b/app/(dashboard)/reports/page.tsx
@@ -45,13 +45,20 @@ export default function ReportsPage() {
   const availableMonths = useMemo(() => {
     const months = []
     const today = new Date()
+    const seen = new Set<string>()
 
     // Generate last 12 months plus current month
     for (let i = 12; i >= 0; i--) {
       const date = new Date(today.getFullYear(), today.getMonth() - i, 1)
       const year = date.getFullYear()
       const month = String(date.getMonth() + 1).padStart(2, "0")
-      months.push(`${year}-${month}`)
+      const monthKey = `${year}-${month}`
+      
+      // Only add if not already seen (prevent duplicates)
+      if (!seen.has(monthKey)) {
+        seen.add(monthKey)
+        months.push(monthKey)
+      }
     }
 
     return months
@@ -827,14 +834,14 @@ export default function ReportsPage() {
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      {availableMonths.map((month) => {
+                      {availableMonths.map((month, index) => {
                         const [year, monthNum] = month.split("-")
                         const monthName = new Date(Number(year), Number(monthNum) - 1).toLocaleDateString("en-US", {
                           year: "numeric",
                           month: "long",
                         })
                         return (
-                          <SelectItem key={month} value={month}>
+                          <SelectItem key={`${month}-${index}`} value={month}>
                             {monthName}
                           </SelectItem>
                         )


### PR DESCRIPTION
- Add deduplication logic to availableMonths useMemo using Set
- Use index in month mapping keys to ensure uniqueness (month-index combination)
- Fix getMonthlyExpenseTrend to return sorted unique months
- Fix maintenance page month selector to use unique keys
- Fix category access in getExpenseReport to handle array responses
- Resolves issue #66: Encountered two children with the same key, 2026-03

The issue was caused by:
1. Potential duplicate months in availableMonths array
2. Using only month value as key instead of unique identifier
3. Month data from API potentially having duplicates

All month mappings now use unique keys (month + index) to prevent React key conflicts.

fixes #66 