### PR TITLE
fix: CSP without unsafe-eval in production (#83)

### DIFF
--- a/docs/security-guidelines.md
+++ b/docs/security-guidelines.md
@@ -166,8 +166,23 @@ admin'--
 
 All of these should be safely handled by Supabase's parameterized queries.
 
+## Content Security Policy (CSP) and eval
+
+To reduce XSS and code-injection risk, the app uses a strict Content Security Policy that **does not allow `eval()` in production** (see [issue #83](https://github.com/jonusgreen/Propeerty_Management/issues/83)).
+
+### What we do
+
+- **CSP headers** are set in `proxy.ts`: script execution uses nonces and `'strict-dynamic'`. `'unsafe-eval'` is allowed **only in development** (for React/Next.js error stack reconstruction).
+- **ESLint** enforces: `no-eval`, `no-implied-eval`, and `no-new-func` so application code does not use `eval()`, `new Function()`, or string forms of `setTimeout`/`setInterval`.
+
+### What to avoid
+
+- Do not use `eval()`, `new Function()`, `setTimeout("string")`, or `setInterval("string")` in application code.
+- Do not add `'unsafe-eval'` to the production CSP. If a dependency requires eval, prefer replacing it or loading it in a sandboxed context.
+
 ## Resources
 
 - [Supabase Security Best Practices](https://supabase.com/docs/guides/database/postgres/row-level-security)
 - [OWASP SQL Injection Prevention](https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html)
 - [PostgreSQL Security](https://www.postgresql.org/docs/current/sql-syntax.html)
+- [Next.js Content Security Policy](https://nextjs.org/docs/app/guides/content-security-policy)

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,10 @@ const config = [
   ...next,
   {
     rules: {
+      // CSP: avoid eval and string-based code execution (issue #83)
+      "no-eval": "error",
+      "no-implied-eval": "error",
+      "no-new-func": "error",
       // Allow some common patterns that are safe
       "react-hooks/exhaustive-deps": "warn", // Make it a warning instead of error
       "react/no-unescaped-entities": "error", // Keep as error but we'll fix them

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,14 +1,50 @@
 import { NextResponse, type NextRequest } from "next/server"
 import { createServerClient } from "@supabase/ssr"
 
+/**
+ * Content Security Policy: no 'unsafe-eval' in production (fixes #83).
+ * In development, React/Next.js use eval for error stack reconstruction, so we allow it only then.
+ */
+function buildCspHeaders(
+  request: NextRequest,
+  nonce: string
+): { requestHeaders: Headers; cspValue: string } {
+  const isDev = process.env.NODE_ENV === "development"
+  const supabaseOrigin = process.env.NEXT_PUBLIC_SUPABASE_URL
+    ? new URL(process.env.NEXT_PUBLIC_SUPABASE_URL).origin
+    : ""
+
+  const cspHeader = [
+    "default-src 'self'",
+    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'${isDev ? " 'unsafe-eval'" : ""}`,
+    `style-src 'self' 'nonce-${nonce}'`,
+    "img-src 'self' blob: data:",
+    "font-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+    ...(supabaseOrigin ? [`connect-src 'self' ${supabaseOrigin}`] : ["connect-src 'self'"]),
+    "upgrade-insecure-requests",
+  ].join("; ")
+
+  const requestHeaders = new Headers(request.headers)
+  requestHeaders.set("x-nonce", nonce)
+  requestHeaders.set("Content-Security-Policy", cspHeader)
+
+  return { requestHeaders, cspValue: cspHeader }
+}
+
 export async function proxy(request: NextRequest) {
-  const { pathname } = request.nextUrl
+  const nonce = Buffer.from(crypto.randomUUID()).toString("base64")
+  const { requestHeaders, cspValue } = buildCspHeaders(request, nonce)
 
   const response = NextResponse.next({
     request: {
-      headers: request.headers,
+      headers: requestHeaders,
     },
   })
+  response.headers.set("Content-Security-Policy", cspValue)
 
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,


### PR DESCRIPTION
- Add nonce-based CSP in proxy (unsafe-eval only in dev)
- Add ESLint: no-eval, no-implied-eval, no-new-func
- Document CSP and eval policy in security-guidelines.md